### PR TITLE
POC of participant event injestion

### DIFF
--- a/src/Sia.Gateway/Controllers/BaseController.cs
+++ b/src/Sia.Gateway/Controllers/BaseController.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Sia.Gateway.Authentication;
 using Sia.Gateway.Validation.Filters;
 
@@ -14,16 +15,19 @@ namespace Sia.Gateway.Controllers
         protected readonly IMediator _mediator;
         protected readonly AzureActiveDirectoryAuthenticationInfo _authConfig;
         protected readonly IUrlHelper _urlHelper;
+        protected readonly ILoggerFactory _loggerFactory;
 
         protected AuthenticatedUserContext _authContext => new AuthenticatedUserContext(User, HttpContext.Session, _authConfig);
 
         protected BaseController(IMediator mediator, 
             AzureActiveDirectoryAuthenticationInfo authConfig,
+            ILoggerFactory loggerFactory,
             IUrlHelper urlHelper)
         {
             _mediator = mediator;
             _authConfig = authConfig;
             _urlHelper = urlHelper;
+            _loggerFactory = loggerFactory;
         }
 
     }

--- a/src/Sia.Gateway/Controllers/EngagementsController.cs
+++ b/src/Sia.Gateway/Controllers/EngagementsController.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Sia.Domain.ApiModels;
 using Sia.Gateway.Authentication;
 using Sia.Gateway.Requests;
@@ -12,8 +13,8 @@ namespace Sia.Gateway.Controllers
     {
         private const string notFoundMessage = "Incident or engagement not found";
 
-        public EngagementsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, IUrlHelper urlHelper) 
-            : base(mediator, authConfig, urlHelper)
+        public EngagementsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, ILoggerFactory loggerFactory, IUrlHelper urlHelper) 
+            : base(mediator, authConfig, loggerFactory, urlHelper)
         {
         }
 

--- a/src/Sia.Gateway/Controllers/IncidentsController.cs
+++ b/src/Sia.Gateway/Controllers/IncidentsController.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Sia.Domain;
 using Sia.Domain.ApiModels;
 using Sia.Gateway.Authentication;
@@ -12,8 +13,8 @@ namespace Sia.Gateway.Controllers
     public class IncidentsController : BaseController
     {
 
-        public IncidentsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, IUrlHelper urlHelper) 
-            : base(mediator, authConfig, urlHelper)
+        public IncidentsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, ILoggerFactory loggerFactory, IUrlHelper urlHelper) 
+            : base(mediator, authConfig, loggerFactory, urlHelper)
         {
         }
 

--- a/src/Sia.Gateway/Controllers/TicketsController.cs
+++ b/src/Sia.Gateway/Controllers/TicketsController.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Sia.Domain;
 using Sia.Gateway.Authentication;
 using Sia.Gateway.Requests;
@@ -11,8 +12,8 @@ namespace Sia.Gateway.Controllers
     [Route("[controller]")]
     public class TicketsController : BaseController
     {
-        public TicketsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, IUrlHelper urlHelper) 
-            : base(mediator, authConfig, urlHelper)
+        public TicketsController(IMediator mediator, AzureActiveDirectoryAuthenticationInfo authConfig, ILoggerFactory loggerFactory, IUrlHelper urlHelper) 
+            : base(mediator, authConfig, loggerFactory, urlHelper)
         {
         }
 

--- a/src/Sia.Gateway/Sia.Gateway.csproj
+++ b/src/Sia.Gateway/Sia.Gateway.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.16.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sia.Gateway/appsettings.json
+++ b/src/Sia.Gateway/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Debug"
     }
   },
   "Authentication": {


### PR DESCRIPTION
This is a POC and only for showing API data format (ParticipantMessage). Please do not merge. 

As part of end-to-end POC, I simply use Events endpoint for short prototyping time. Here are a couple of issues we should consider.

1. If we don't differentiate type of events at Resource/endpoint level and use event type in http body, we will need to figure out how to de-serialize part of body before creating a particular type of Event. Otherwise, deserialization is straight forward as showed in the code with an additional .../events/participant Resource.
2. In this POC, ICM incidentId from SreBot (event source) is used as {incidentId} in event API endpoint. So meaning of incidentId is overloaded as we talked about earlier.