### PR TITLE
MockFactory now creates fresh service provider and fresh in-memory db.

### DIFF
--- a/src/Sia.Connectors.Tickets/Sia.Connectors.Tickets.csproj
+++ b/src/Sia.Connectors.Tickets/Sia.Connectors.Tickets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PackageId>Microsoft.Sia.Connectors.Tickets</PackageId>
-    <Version>1.1.10-alpha</Version>
+    <Version>1.1.25-alpha</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Product>SRE Incident Assistant</Product>

--- a/test/Sia.Gateway.Tests/TestDoubles/MockFactory.cs
+++ b/test/Sia.Gateway.Tests/TestDoubles/MockFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Sia.Gateway.Tests.TestDoubles
 {
@@ -27,9 +28,7 @@ namespace Sia.Gateway.Tests.TestDoubles
 
             if(_contextBeingGenerated.TryAdd(instance, true))
             {
-                var options = new DbContextOptionsBuilder<IncidentContext>()
-                    .UseInMemoryDatabase(instance)
-                    .Options;
+                var options = CreateFreshContextAndDb(instance);
                 context = new IncidentContext(options);
                 SeedData.Add(context);
                 _contextBeingGenerated.TryAdd(instance, false);
@@ -42,5 +41,17 @@ namespace Sia.Gateway.Tests.TestDoubles
 
         private static ConcurrentDictionary<string, bool> _contextBeingGenerated { get; set; } = new ConcurrentDictionary<string, bool>();
         private static ConcurrentDictionary<string, IncidentContext> _contexts { get; set; } = new ConcurrentDictionary<string, IncidentContext>();
+
+        private static DbContextOptions<IncidentContext> CreateFreshContextAndDb(string instance)
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .BuildServiceProvider();
+            var builder = new DbContextOptionsBuilder<IncidentContext>()
+                .UseInMemoryDatabase(instance)
+                .UseInternalServiceProvider(serviceProvider);
+            return builder.Options;
+        }
     }
+
 }


### PR DESCRIPTION
This fixes id increment issues when running tests in parallel.  Each test gets its own db instance.