### PR TITLE
Compliance: Update System.Net.Security per compliance scan

### DIFF
--- a/src/Sia.Gateway/Sia.Gateway.csproj
+++ b/src/Sia.Gateway/Sia.Gateway.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Net.Security" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />


### PR DESCRIPTION
Manually upgrade System.Net.Security to the latest stable version, compatible version as the currently included version (4.3.0 was flagged as vulnerable by a security scan)